### PR TITLE
Python 'six' package installation

### DIFF
--- a/3.10-alpine/Dockerfile
+++ b/3.10-alpine/Dockerfile
@@ -4,7 +4,9 @@ FROM python:3.10-alpine
 # Update operating system & install GCC for
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \
-        gcc
+        gcc \
+    && apk add \
+      py3-six
 
 
 # Copy python dependencies list

--- a/3.10-alpine/requirements.txt
+++ b/3.10-alpine/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1

--- a/3.10-buster/Dockerfile
+++ b/3.10-buster/Dockerfile
@@ -1,6 +1,11 @@
 # Start with release canidate buster image
 FROM python:3.10-buster
 
+# Update operating system & install system packages
+RUN apt-get update \
+    && apt-get install -y \
+    	python3-six
+
 # Copy python dependencies list
 COPY ./ /
 

--- a/3.10-buster/requirements.txt
+++ b/3.10-buster/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1

--- a/3.11-alpine/Dockerfile
+++ b/3.11-alpine/Dockerfile
@@ -4,7 +4,9 @@ FROM python:3.11-alpine
 # Update operating system & install GCC for
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \
-        gcc
+        gcc \
+    && apk add \
+      py3-six
 
 
 # Copy python dependencies list

--- a/3.11-alpine/requirements.txt
+++ b/3.11-alpine/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1

--- a/3.11-buster/Dockerfile
+++ b/3.11-buster/Dockerfile
@@ -1,6 +1,11 @@
 # Start with release canidate buster image
 FROM python:3.11-buster
 
+# Update operating system & install system packages
+RUN apt-get update \
+    && apt-get install -y \
+    	python3-six
+
 # Copy python dependencies list
 COPY ./ /
 

--- a/3.11-buster/requirements.txt
+++ b/3.11-buster/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1

--- a/3.12-alpine/Dockerfile
+++ b/3.12-alpine/Dockerfile
@@ -4,7 +4,9 @@ FROM python:3.12-alpine
 # Update operating system & install GCC for
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \
-        gcc
+        gcc \
+    && apk add \
+      py3-six
 
 # Copy python dependencies list
 COPY ./ /

--- a/3.12-alpine/requirements.txt
+++ b/3.12-alpine/requirements.txt
@@ -9,6 +9,6 @@ PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
 setuptools==69.2.0
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1
 wheel==0.43.0

--- a/3.12-bullseye/Dockerfile
+++ b/3.12-bullseye/Dockerfile
@@ -1,6 +1,11 @@
 # Start with release canidate buster image
 FROM python:3.12-bullseye
 
+# Update operating system & install system packages
+RUN apt-get update \
+    && apt-get install -y \
+    	python3-six
+
 # Copy python dependencies list
 COPY ./ /
 

--- a/3.12-bullseye/requirements.txt
+++ b/3.12-bullseye/requirements.txt
@@ -9,6 +9,6 @@ PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
 setuptools==69.1.1
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1
 wheel==0.43.0

--- a/3.12-slim/Dockerfile
+++ b/3.12-slim/Dockerfile
@@ -1,6 +1,11 @@
 # Start with release canidate buster image
 FROM python:3.12-slim
 
+# Update operating system & install system packages
+RUN apt-get update \
+    && apt-get install -y \
+    	python3-six
+
 # Copy python dependencies list
 COPY ./ /
 

--- a/3.12-slim/requirements.txt
+++ b/3.12-slim/requirements.txt
@@ -9,6 +9,6 @@ PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
 setuptools==69.1.1
-six==1.16.0
+six>=1.16.0
 urllib3==2.2.1
 wheel==0.43.0

--- a/3.9-alpine/Dockerfile
+++ b/3.9-alpine/Dockerfile
@@ -4,7 +4,9 @@ FROM python:3.9-alpine
 # Update operating system & install GCC for
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \
-        gcc
+        gcc \
+    && apk add \
+      py3-six
 
 
 # Copy python dependencies list

--- a/3.9-alpine/requirements.txt
+++ b/3.9-alpine/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 urllib3==1.26.18

--- a/3.9-buster/Dockerfile
+++ b/3.9-buster/Dockerfile
@@ -1,6 +1,11 @@
 # Start with release canidate buster image
 FROM python:3.9-buster
 
+# Update operating system & install system packages
+RUN apt-get update \
+    && apt-get install -y \
+    	python3-six
+
 # Copy python dependencies list
 COPY ./ /
 

--- a/3.9-buster/requirements.txt
+++ b/3.9-buster/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 urllib3==1.26.18


### PR DESCRIPTION
- add 'six' to system package installations
- fix 'six' version constraint in requirements.txt to allow for system packages to install the latest version