### PR TITLE
Python 3.9 'urllib3' version constraint

### DIFF
--- a/3.9-alpine/requirements.txt
+++ b/3.9-alpine/requirements.txt
@@ -9,4 +9,5 @@ PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
 six>=1.16.0
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"

--- a/3.9-buster/requirements.txt
+++ b/3.9-buster/requirements.txt
@@ -9,4 +9,5 @@ PyYAML==6.0.1
 rsa==4.7.2
 s3transfer==0.10.1
 six>=1.16.0
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"


### PR DESCRIPTION
- fix urllib3 version constraint for Python 3.9 & lower