### PR TITLE
Update Debian source list prior to "apt-get update" command

### DIFF
--- a/3.10-buster/Dockerfile
+++ b/3.10-buster/Dockerfile
@@ -1,6 +1,9 @@
 # Start with release canidate buster image
 FROM python:3.10-buster
 
+# Update source list
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+
 # Update operating system & install system packages
 RUN apt-get update \
     && apt-get install -y \

--- a/3.11-buster/Dockerfile
+++ b/3.11-buster/Dockerfile
@@ -1,6 +1,9 @@
 # Start with release canidate buster image
 FROM python:3.11-buster
 
+# Update source list
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+
 # Update operating system & install system packages
 RUN apt-get update \
     && apt-get install -y \

--- a/3.9-buster/Dockerfile
+++ b/3.9-buster/Dockerfile
@@ -1,6 +1,9 @@
 # Start with release canidate buster image
 FROM python:3.9-buster
 
+# Update source list
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+
 # Update operating system & install system packages
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
- fix issue with apt-get commands failing due to outdated source list